### PR TITLE
Change dockerfile to use Freyja from github source

### DIFF
--- a/.github/workflows/update_freyja.yml
+++ b/.github/workflows/update_freyja.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: ./freyja/Dockerfile
-          build-args: FREYJA_SOFTWARE_VERSION=${{ steps.strip.outputs.version }}
+          build-args: FREYJA_GITHUB_SOFTWARE_VERSION=${{ steps.strip.outputs.version }}
           push: true
           tags: quay.io/uphl/freyja:${{ steps.strip.outputs.version }}-${{ steps.date.outputs.date }}
 
@@ -64,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: ./freyja/Dockerfile
-          build-args: FREYJA_SOFTWARE_VERSION=${{ steps.strip.outputs.version }}
+          build-args: FREYJA_GITHUB_SOFTWARE_VERSION=${{ steps.strip.outputs.version }}
           push: true
           tags: quay.io/uphl/freyja:latest   
 

--- a/freyja/Dockerfile
+++ b/freyja/Dockerfile
@@ -5,7 +5,7 @@ FROM mambaorg/micromamba:2.0.2 as app
 # Bioconda Freyja version
 ARG FREYJA_BASE_SOFTWARE_VERSION="1.5.1"
 # Set if you want to override with a specific Github version tag
-ARG FREYJA_UPDATE_SOFTWARE_VERSION="v1.5.2"
+ARG FREYJA_GITHUB_SOFTWARE_VERSION="1.5.2"
 
 # build and run as root users since micromamba image has 'mambauser' set as the $USER
 USER root
@@ -15,7 +15,7 @@ WORKDIR /
 LABEL base.image="mambaorg/micromamba:2.0.2"
 LABEL dockerfile.version="1"
 LABEL software="Freyja"
-LABEL software.version=${FREYJA_SOFTWARE_VERSION}
+LABEL software.version=${FREYJA_GITHUB_SOFTWARE_VERSION}
 LABEL description="Freyja is a tool to recover relative lineage abundances from mixed SARS-CoV-2 samples from a sequencing dataset (BAM aligned to the Hu-1 reference)"
 LABEL website="https://github.com/andersen-lab/Freyja"
 LABEL license="https://github.com/andersen-lab/Freyja/blob/main/LICENSE"
@@ -39,7 +39,7 @@ ENV PATH="/opt/conda/envs/freyja-env/bin:/opt/conda/envs/env/bin:${PATH}" \
     LC_ALL=C.UTF-8
 
 # Install freyja from Github source file
-RUN git clone --depth 1 --branch ${FREYJA_UPDATE_SOFTWARE_VERSION} https://github.com/andersen-lab/Freyja.git
+RUN git clone --depth 1 --branch v${FREYJA_GITHUB_SOFTWARE_VERSION} https://github.com/andersen-lab/Freyja.git
 RUN pip install ./Freyja
 
 RUN pip install pyarrow

--- a/freyja/Dockerfile
+++ b/freyja/Dockerfile
@@ -1,27 +1,79 @@
-FROM mambaorg/micromamba:1.4
+FROM mambaorg/micromamba:2.0.2 as app
 
-ARG FREYJA_SOFTWARE_VERSION="1.4.7"
+# Version arguments
+# ARG variables only persist during build time
+# Bioconda Freyja version
+ARG FREYJA_BASE_SOFTWARE_VERSION="1.5.1"
+# Set if you want to override with a specific Github version tag
+ARG FREYJA_UPDATE_SOFTWARE_VERSION="v1.5.2"
 
+# build and run as root users since micromamba image has 'mambauser' set as the $USER
 USER root
+# set workdir to default for building; set to /data at the end
 WORKDIR /
 
+LABEL base.image="mambaorg/micromamba:2.0.2"
+LABEL dockerfile.version="1"
+LABEL software="Freyja"
+LABEL software.version=${FREYJA_SOFTWARE_VERSION}
+LABEL description="Freyja is a tool to recover relative lineage abundances from mixed SARS-CoV-2 samples from a sequencing dataset (BAM aligned to the Hu-1 reference)"
+LABEL website="https://github.com/andersen-lab/Freyja"
+LABEL license="https://github.com/andersen-lab/Freyja/blob/main/LICENSE"
+
+
+# install dependencies; cleanup apt garbage
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     ca-certificates \
     procps && \
     apt-get autoclean && rm -rf /var/lib/apt/lists/*
 
-RUN micromamba create -n freyja-env -c conda-forge -c bioconda -c defaults freyja=${FREYJA_SOFTWARE_VERSION} && \
-    micromamba clean -a -y
+# Create Freyja conda environment called freyja-env from bioconda recipe
+# clean up conda garbage
+# Install git to allow git clone
+RUN micromamba create -n freyja-env -c conda-forge -c bioconda -c defaults git freyja=${FREYJA_BASE_SOFTWARE_VERSION} && \
+  micromamba clean -a -y
 
+# set the environment, put new conda env in PATH by default
 ENV PATH="/opt/conda/envs/freyja-env/bin:/opt/conda/envs/env/bin:${PATH}" \
     LC_ALL=C.UTF-8
 
+# Install freyja from Github source file
+RUN git clone --depth 1 --branch ${FREYJA_UPDATE_SOFTWARE_VERSION} https://github.com/andersen-lab/Freyja.git
+RUN pip install ./Freyja
+
+RUN pip install pyarrow
+
+# update barcodes
+# NOTE: this will download the latest version of the `freyja/data/usher_barcodes.csv` file from GitHub
 RUN freyja update
 
-RUN wget https://raw.githubusercontent.com/andersen-lab/Freyja/main/freyja/data/usher_barcodes.csv && \
-    mv -f usher_barcodes.csv /opt/conda/envs/freyja-env/lib/python3.10/site-packages/freyja/data/usher_barcodes.csv
-
+# set working directory to /data
 WORKDIR /data
 
-CMD freyja --help
+# default command is to pull up help options
+CMD [ "freyja", "--help" ]
+
+# new base for testing
+FROM app as test
+
+RUN freyja --help && freyja --version
+
+# Grab test data from Freyja version 1.3.4
+RUN wget -O /data/Freyja_WWSC2.bam https://github.com/StaPH-B/docker-builds/blob/master/freyja/1.3.4/tests/Freyja_WWSC2.bam?raw=true && \
+    wget -P /data https://raw.githubusercontent.com/StaPH-B/docker-builds/master/freyja/1.3.4/tests/Freyja_depths.tsv && \
+    wget -P /data https://raw.githubusercontent.com/StaPH-B/docker-builds/master/freyja/1.3.4/tests/Freyja_variants.tsv && \
+    wget -P /data https://raw.githubusercontent.com/StaPH-B/docker-builds/master/freyja/1.3.4/tests/nCoV-2019.reference.fasta
+
+# Run Freyja
+RUN freyja variants /data/Freyja_WWSC2.bam --variants /data/test_variants.tsv --depths /data/test_depths.tsv --ref /data/nCoV-2019.reference.fasta && \
+    freyja demix /data/test_variants.tsv /data/test_depths.tsv --output /data/test_demix.tsv
+
+# Check validity of outputs
+RUN head /data/test_variants.tsv && \
+    head /data/test_depths.tsv && \
+    head /data/test_demix.tsv && \
+    grep "Omicron" /data/test_demix.tsv
+
+# print barcode version and freyja version
+RUN freyja demix --version


### PR DESCRIPTION
Changelist:
- Changed micromamba base image 1.4 -> 2.0.2
- Changed base Freyja version 1.4.7 -> 1.5.1
- Add override to use Freyja v1.5.2 from Github source
- Add docker image labels, copied from Staphb's freyja docker image
- Add git to allow git clone
- Add freyja update for updating barcodes
- Add test layer for validating image, copied from Staphb's freyja docker image
- Update Freyja Github Docker upload action to match the new image